### PR TITLE
Use semver library to identify pre-releases

### DIFF
--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -10,6 +10,7 @@ import { CompletionItem, CompletionItemKind, CompletionList, workspace } from "v
 import { sortText } from "../providers/autoCompletion";
 import { CrateMetadatas } from "../api/crateMetadatas";
 import { AlternateRegistry } from "./AlternateRegistry";
+import { prerelease } from "semver";
 
 export async function fetchCrateVersions(dependencies: Item[], alternateRegistries?: AlternateRegistry[]): Promise<[Promise<Dependency[]>, Map<string, Dependency[]>]> {
   // load config
@@ -34,7 +35,7 @@ function transformServerResponse(versions: (name: string, indexServerURL?: strin
     var thisCrateToken = item.registry !== undefined ? alternateRegistry?.token : undefined;
     return versions(item.key, thisCrateRegistry, thisCrateToken).then((crate: any) => {
       const versions = crate.versions.reduce((result: any[], item: string) => {
-        const isPreRelease = !shouldListPreRels && (item.indexOf("-alpha") !== -1 || item.indexOf("-beta") !== -1 || item.indexOf("-rc") !== -1 || item.indexOf("-pre") !== -1);
+        const isPreRelease = !shouldListPreRels && prerelease(item);
         if (!isPreRelease)
           result.push(item);
         return result;


### PR DESCRIPTION
I noticed while using a crate (`leptos`) that had a "non-standard" pre-release version that it wasn't handled properly by the extension (`0.7.0-gamma3`). The semver library has a `prerelease` function (https://www.npmjs.com/package/semver#functions) so I just used that. Cargo's docs (https://doc.rust-lang.org/cargo/reference/resolver.html#pre-releases) seem to agree with semver's spec on pre-releases (https://semver.org/#spec-item-9) so it should work well for this.

>  prerelease(v): Returns an array of prerelease components, or null if none exist. Example: prerelease('1.2.3-alpha.1') -> ['alpha', 1] 