### PR TITLE
feat: add dependency feature lookup by used version

### DIFF
--- a/src/api/crateMetadatas.ts
+++ b/src/api/crateMetadatas.ts
@@ -1,5 +1,5 @@
 export type CrateMetadatas = {
     name: string,
     versions: Array<string>,
-    features: Array<string>
+    features?: Array<string>
 }

--- a/src/api/sparse-index-server.ts
+++ b/src/api/sparse-index-server.ts
@@ -2,16 +2,87 @@ import * as https from 'https';
 import * as http from 'http';
 import { CrateMetadatas } from './crateMetadatas';
 import NodeCache from "node-cache";
+import { maxSatisfying, prerelease } from "semver";
 
 export const sparseIndexServerURL = "https://index.crates.io";
 const cache = new NodeCache({ stdTTL: 60 * 10 });
 
-export const versions = (name: string, indexServerURL?: string, registryToken?: string) => {
+function normalizeVersionRequirement(versionRequirement?: string): string | undefined {
+  if (!versionRequirement) return undefined;
+  const trimmed = versionRequirement.trim();
+  if (trimmed.length === 0) return undefined;
+  const prefix = trimmed.charCodeAt(0);
+  if (prefix > 47 && prefix < 58) return "^" + trimmed;
+  return trimmed;
+}
+
+function extractFeaturesFromEntry(entry: any): string[] {
+  const merged = {
+    ...(entry.features ?? {}),
+    ...(entry.features2 ?? {}),
+  };
+  return Object.keys(merged);
+}
+
+export function buildCrateMetadatasFromSparseLines(
+  name: string,
+  lines: string[],
+  versionRequirement?: string,
+  shouldListPreRels: boolean = false
+): CrateMetadatas {
+  const bodyArray: any[] = [];
+  for (const line of lines) {
+    bodyArray.push(JSON.parse(line));
+  }
+
+  const nonYanked = bodyArray.filter((e: any) => e.yanked === false);
+  const allVersions = nonYanked.map((e: any) => e.vers);
+
+  const candidateVersions = shouldListPreRels
+    ? allVersions
+    : allVersions.filter((version) => !prerelease(version));
+
+  const normalizedRequirement = normalizeVersionRequirement(versionRequirement);
+  let resolvedVersion: string | null = null;
+  const prereleaseOptions = shouldListPreRels ? { includePrerelease: true } : undefined;
+  if (normalizedRequirement) {
+    resolvedVersion = maxSatisfying(candidateVersions, normalizedRequirement, prereleaseOptions);
+    if (!resolvedVersion) {
+      resolvedVersion = maxSatisfying(allVersions, normalizedRequirement, { includePrerelease: true });
+    }
+  } else {
+    resolvedVersion = maxSatisfying(candidateVersions, "*", prereleaseOptions);
+    if (!resolvedVersion && shouldListPreRels) {
+      resolvedVersion = maxSatisfying(allVersions, "*", { includePrerelease: true });
+    }
+  }
+
+  const resolvedEntry = resolvedVersion
+    ? nonYanked.find((entry: any) => entry.vers === resolvedVersion)
+    : undefined;
+
+  const features = resolvedEntry ? extractFeaturesFromEntry(resolvedEntry) : [];
+
+  return {
+    name,
+    versions: allVersions,
+    features,
+  };
+}
+
+export const versions = (
+  name: string,
+  indexServerURL?: string,
+  registryToken?: string,
+  versionRequirement?: string,
+  shouldListPreRels: boolean = false
+) => {
   // clean dirty names
   name = name.replace(/"/g, "");
+  const cacheKey = `${name}::${versionRequirement ?? ""}::${shouldListPreRels ? "pre" : "stable"}`;
 
   return new Promise<CrateMetadatas>(function (resolve, reject) {
-    const cached = cache.get<CrateMetadatas>(name);
+    const cached = cache.get<CrateMetadatas>(cacheKey);
     if (cached) {
       resolve(cached);
       return;
@@ -64,16 +135,8 @@ export const versions = (name: string, indexServerURL?: string, registryToken?: 
       res.on('end', function () {
         try {
           var body_lines = Buffer.concat(body).toString().split('\n').filter(n => n);
-          var body_array: any = [];
-          for (var line of body_lines) {
-            body_array.push(JSON.parse(line));
-          }
-          crate_metadatas = {
-            name: name,
-            versions: body_array.filter((e: any) => e.yanked === false).map((e: any) => e.vers),
-            features: Object.keys(body_array.at(-1).features).filter(feature => feature !== "default")
-          };
-          cache.set(name, crate_metadatas);
+          crate_metadatas = buildCrateMetadatasFromSparseLines(name, body_lines, versionRequirement, shouldListPreRels);
+          cache.set(cacheKey, crate_metadatas);
         } catch (e) {
           reject(e);
         }

--- a/src/api/sparse-index-server.ts
+++ b/src/api/sparse-index-server.ts
@@ -9,11 +9,11 @@ const cache = new NodeCache({ stdTTL: 60 * 10 });
 
 function normalizeVersionRequirement(versionRequirement?: string): string | undefined {
   if (!versionRequirement) return undefined;
-  const trimmed = versionRequirement.trim();
-  if (trimmed.length === 0) return undefined;
-  const prefix = trimmed.charCodeAt(0);
-  if (prefix > 47 && prefix < 58) return "^" + trimmed;
-  return trimmed;
+  const normalized = versionRequirement.replace(/,/g, ' ').trim();
+  if (normalized.length === 0) return undefined;
+  const prefix = normalized.charCodeAt(0);
+  if (prefix > 47 && prefix < 58) return "^" + normalized;
+  return normalized;
 }
 
 function extractFeaturesFromEntry(entry: any): string[] {
@@ -79,7 +79,8 @@ export const versions = (
 ) => {
   // clean dirty names
   name = name.replace(/"/g, "");
-  const cacheKey = `${name}::${versionRequirement ?? ""}::${shouldListPreRels ? "pre" : "stable"}`;
+  const registryScope = indexServerURL?.replace(/\/$/, "") ?? "default";
+  const cacheKey = `${registryScope}::${name}::${versionRequirement ?? ""}::${shouldListPreRels ? "pre" : "stable"}`;
 
   return new Promise<CrateMetadatas>(function (resolve, reject) {
     const cached = cache.get<CrateMetadatas>(cacheKey);

--- a/src/core/Dependency.ts
+++ b/src/core/Dependency.ts
@@ -7,8 +7,8 @@ import Item from "./Item";
 export default interface Dependency {
   item: Item;
   versions?: Array<string>;
+  features?: Array<string>;
   error?: string;
 
   versionCompletionItems?: CompletionList;
-  featureCompletionItems?: Map<string, CompletionList>;
 }

--- a/src/core/Item.ts
+++ b/src/core/Item.ts
@@ -6,6 +6,8 @@ export default class Item {
   values: Array<Item> = [];
   value: string | undefined = "";
   registry?: string;
+  path?: string;
+  workspace?: boolean;
   start: number = -1;
   end: number = -1;
   constructor(item?: Item) {
@@ -14,6 +16,8 @@ export default class Item {
       this.values = item.values;
       this.value = item.value;
       this.registry = item.registry;
+      this.path = item.path;
+      this.workspace = item.workspace;
       this.start = item.start;
       this.end = item.end;
     }

--- a/src/core/featureSources.ts
+++ b/src/core/featureSources.ts
@@ -10,6 +10,10 @@ export type FeatureSourceResult = {
     features: string[];
 };
 
+export function isLocalFeatureSourceDependency(dependency: Item): boolean {
+    return dependency.path !== undefined || dependency.workspace === true;
+}
+
 function toFeatureSourceResult(features: string[]): FeatureSourceResult {
     return {
         versions: [LOCAL_FEATURES_VERSION],

--- a/src/core/featureSources.ts
+++ b/src/core/featureSources.ts
@@ -1,0 +1,162 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import Item from "./Item";
+import { parse } from "../toml/parser";
+
+export const LOCAL_FEATURES_VERSION = "__local__";
+
+export type FeatureSourceResult = {
+    versions: string[];
+    features: string[];
+};
+
+function toFeatureSourceResult(features: string[]): FeatureSourceResult {
+    return {
+        versions: [LOCAL_FEATURES_VERSION],
+        features,
+    };
+}
+
+export function parseManifestFeatureData(manifestContent: string): FeatureSourceResult {
+    const parsed = parse(manifestContent);
+    const featuresTable = parsed.values.find((item) => item.key === "features");
+
+    if (!featuresTable) {
+        return toFeatureSourceResult([]);
+    }
+
+    const features = featuresTable.values.map((featureItem) => {
+        return featureItem.key;
+    });
+
+    return toFeatureSourceResult(features);
+}
+
+function resolveManifestPath(baseCargoTomlPath: string, relativeOrFilePath: string): string {
+    const absPath = path.resolve(path.dirname(baseCargoTomlPath), relativeOrFilePath);
+    if (path.basename(absPath).toLowerCase() === "cargo.toml") {
+        return absPath;
+    }
+    return path.join(absPath, "Cargo.toml");
+}
+
+async function findWorkspaceCargo(startCargoTomlPath: string): Promise<string | undefined> {
+    let currentDir = path.dirname(startCargoTomlPath);
+
+    while (true) {
+        const candidate = path.join(currentDir, "Cargo.toml");
+        try {
+            const content = await fs.readFile(candidate, "utf-8");
+            const parsed = parse(content);
+            const hasWorkspace = parsed.values.some((item) => item.key === "workspace" || item.key.startsWith("workspace."));
+            if (hasWorkspace) {
+                return candidate;
+            }
+        } catch {
+            // ignore and continue walking upward
+        }
+
+        const parent = path.dirname(currentDir);
+        if (parent === currentDir) return undefined;
+        currentDir = parent;
+    }
+}
+
+function findWorkspaceDependencyItem(workspaceManifestContent: string, crateName: string): Item | undefined {
+    const parsed = parse(workspaceManifestContent);
+
+    const direct = parsed.values.find((value) => value.key === `workspace.dependencies.${crateName}`);
+    if (direct) return direct;
+
+    const workspaceDepsTable = parsed.values.find((value) => value.key === "workspace.dependencies");
+    if (!workspaceDepsTable) return undefined;
+
+    return workspaceDepsTable.values.find((value) => value.key === crateName);
+}
+
+function extractPathFromInlineTable(inline: string): string | undefined {
+    const match = inline.match(/path\s*=\s*["']([^"']+)["']/);
+    return match?.[1];
+}
+
+function findWorkspaceDependencyPathByText(workspaceManifestContent: string, crateName: string): string | undefined {
+    const lines = workspaceManifestContent.split(/\r?\n/);
+
+    // [workspace.dependencies] with inline entries
+    let inWorkspaceDependencies = false;
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (line.startsWith("[") && line.endsWith("]")) {
+            inWorkspaceDependencies = line === "[workspace.dependencies]";
+            continue;
+        }
+
+        if (!inWorkspaceDependencies) continue;
+        if (line.startsWith("#") || line.length === 0) continue;
+
+        const inlineMatch = line.match(new RegExp(`^${crateName}\\s*=\\s*\\{(.+)\\}$`));
+        if (inlineMatch) {
+            const parsedPath = extractPathFromInlineTable(inlineMatch[1]);
+            if (parsedPath) return parsedPath;
+        }
+    }
+
+    // [workspace.dependencies.<crate>] table form
+    const tableHeader = `[workspace.dependencies.${crateName}]`;
+    let inCrateTable = false;
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (line.startsWith("[") && line.endsWith("]")) {
+            inCrateTable = line === tableHeader;
+            continue;
+        }
+
+        if (!inCrateTable) continue;
+        if (line.startsWith("#") || line.length === 0) continue;
+
+        const pathMatch = line.match(/^path\s*=\s*["']([^"']+)["']/);
+        if (pathMatch) return pathMatch[1];
+    }
+
+    return undefined;
+}
+
+function readDependencyPath(item: Item | undefined): string | undefined {
+    if (!item) return undefined;
+
+    if (item.values.length > 0) {
+        return item.values.find((value) => value.key === "path")?.value;
+    }
+
+    return undefined;
+}
+
+export async function resolveFeaturesForDependency(
+    dependency: Item,
+    currentCargoTomlPath: string
+): Promise<FeatureSourceResult | undefined> {
+    try {
+        let targetManifestPath: string | undefined;
+
+        if (dependency.path) {
+            targetManifestPath = resolveManifestPath(currentCargoTomlPath, dependency.path);
+        } else if (dependency.workspace === true) {
+            const workspaceCargo = await findWorkspaceCargo(currentCargoTomlPath);
+            if (!workspaceCargo) return undefined;
+
+            const workspaceContent = await fs.readFile(workspaceCargo, "utf-8");
+            const workspaceDepItem = findWorkspaceDependencyItem(workspaceContent, dependency.key);
+            const workspaceDepPath = readDependencyPath(workspaceDepItem) ?? findWorkspaceDependencyPathByText(workspaceContent, dependency.key);
+            if (!workspaceDepPath) return undefined;
+
+            targetManifestPath = resolveManifestPath(workspaceCargo, workspaceDepPath);
+        }
+
+        if (!targetManifestPath) return undefined;
+
+        const targetContent = await fs.readFile(targetManifestPath, "utf-8");
+        return parseManifestFeatureData(targetContent);
+    } catch {
+        return undefined;
+    }
+}

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -11,8 +11,13 @@ import { sortText } from "../providers/autoCompletion";
 import { CrateMetadatas } from "../api/crateMetadatas";
 import { AlternateRegistry } from "./AlternateRegistry";
 import { prerelease } from "semver";
+import { resolveFeaturesForDependency } from "./featureSources";
 
-export async function fetchCrateVersions(dependencies: Item[], alternateRegistries?: AlternateRegistry[]): Promise<[Promise<Dependency[]>, Map<string, Dependency[]>]> {
+export async function fetchCrateVersions(
+  dependencies: Item[],
+  alternateRegistries?: AlternateRegistry[],
+  cargoTomlPath?: string
+): Promise<[Promise<Dependency[]>, Map<string, Dependency[]>]> {
   // load config
   const config = workspace.getConfiguration("");
   const shouldListPreRels = !!config.get("crates.listPreReleases");
@@ -20,20 +25,58 @@ export async function fetchCrateVersions(dependencies: Item[], alternateRegistri
 
   StatusBar.setText("Loading", "👀 Fetching " + indexServerURL.replace(/^https?:\/\//, ''));
 
-  let transformer = transformServerResponse(sparseVersions, shouldListPreRels, indexServerURL, alternateRegistries);
-  let responsesMap: Map<string, Dependency[]> = new Map();
+  let transformer = transformServerResponse(sparseVersions, shouldListPreRels, indexServerURL, alternateRegistries, cargoTomlPath);
   const responses = dependencies.map(transformer);
-  return [Promise.all(responses), responsesMap];
+  const resolvedResponses = await Promise.all(responses);
+  const responsesMap = indexDependenciesByKey(resolvedResponses);
+  return [Promise.resolve(resolvedResponses), responsesMap];
+}
+
+export function indexDependenciesByKey(dependencies: Dependency[]): Map<string, Dependency[]> {
+  const map: Map<string, Dependency[]> = new Map();
+
+  dependencies.forEach((dependency) => {
+    const key = dependency.item.key;
+    const existing = map.get(key) ?? [];
+    existing.push(dependency);
+    map.set(key, existing);
+  });
+
+  return map;
 }
 
 
-function transformServerResponse(versions: (name: string, indexServerURL?: string, registryToken?: string) => Promise<CrateMetadatas>, shouldListPreRels: boolean, indexServerURL: string, alternateRegistries?: AlternateRegistry[]): (i: Item) => Promise<Dependency> {
-  return function (item: Item): Promise<Dependency> {
+function transformServerResponse(
+  versions: (
+    name: string,
+    indexServerURL?: string,
+    registryToken?: string,
+    versionRequirement?: string,
+    shouldListPreRels?: boolean
+  ) => Promise<CrateMetadatas>,
+  shouldListPreRels: boolean,
+  indexServerURL: string,
+  alternateRegistries?: AlternateRegistry[],
+  cargoTomlPath?: string
+): (i: Item) => Promise<Dependency> {
+  return async function (item: Item): Promise<Dependency> {
+    if (cargoTomlPath && (item.path !== undefined || item.workspace === true)) {
+      const localFeatures = await resolveFeaturesForDependency(item, cargoTomlPath);
+      if (localFeatures) {
+        return {
+          item,
+          versions: localFeatures.versions,
+          features: localFeatures.features,
+          versionCompletionItems: new CompletionList([], true),
+        };
+      }
+    }
+
     // Use the sparse index if (and only if) the crate does not use an alternate registry
     const alternateRegistry = alternateRegistries?.find((registry) => item.registry == registry.name);
     var thisCrateRegistry = item.registry !== undefined ? alternateRegistry?.index : indexServerURL;
     var thisCrateToken = item.registry !== undefined ? alternateRegistry?.token : undefined;
-    return versions(item.key, thisCrateRegistry, thisCrateToken).then((crate: any) => {
+    return versions(item.key, thisCrateRegistry, thisCrateToken, item.value, shouldListPreRels).then((crate: any) => {
       const versions = crate.versions.reduce((result: any[], item: string) => {
         const isPreRelease = !shouldListPreRels && prerelease(item);
         if (!isPreRelease)
@@ -57,18 +100,11 @@ function transformServerResponse(versions: (name: string, indexServerURL?: strin
         true
       );
 
-      let featureCompletionItems: Map<string, CompletionList> = new Map();
-      crate.features?.forEach((feature: string) => {
-        // TODO: Add feature completion items according to the different versions.
-        featureCompletionItems!.set(feature, new CompletionList(crate.features.map((feature: string) => {
-          return new CompletionItem(feature, CompletionItemKind.Class);
-        })));
-      });
       return {
         item,
         versions,
+        features: crate.features,
         versionCompletionItems,
-        featureCompletionItems,
       };
     }).catch((error: Error) => {
       console.error(error);

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -11,7 +11,7 @@ import { sortText } from "../providers/autoCompletion";
 import { CrateMetadatas } from "../api/crateMetadatas";
 import { AlternateRegistry } from "./AlternateRegistry";
 import { prerelease } from "semver";
-import { resolveFeaturesForDependency } from "./featureSources";
+import { isLocalFeatureSourceDependency, resolveFeaturesForDependency } from "./featureSources";
 
 export async function fetchCrateVersions(
   dependencies: Item[],
@@ -60,7 +60,7 @@ function transformServerResponse(
   cargoTomlPath?: string
 ): (i: Item) => Promise<Dependency> {
   return async function (item: Item): Promise<Dependency> {
-    if (cargoTomlPath && (item.path !== undefined || item.workspace === true)) {
+    if (cargoTomlPath && isLocalFeatureSourceDependency(item)) {
       const localFeatures = await resolveFeaturesForDependency(item, cargoTomlPath);
       if (localFeatures) {
         return {

--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -16,6 +16,7 @@ import { promises as async_fs } from 'fs';
 import fs from 'fs';
 import { AlternateRegistry } from "./AlternateRegistry";
 import { updateFeatureDiagnostics } from "../ui/featureDiagnostics";
+import { isLocalFeatureSourceDependency } from "./featureSources";
 
 function parseToml(cargoTomlContent: string, alternateRegistries?: AlternateRegistry[]): Item[] {
   console.log("Parsing...");
@@ -105,7 +106,9 @@ export async function parseAndDecorate(
       fetchedDepsMap = data[1];
     }
 
-    decorate(editor, fetchedDeps);
+    const depsForDecoration = fetchedDeps.filter((dep) => !isLocalFeatureSourceDependency(dep.item));
+
+    decorate(editor, depsForDecoration);
     if (fetchedDepsMap) {
       updateFeatureDiagnostics(editor.document, fetchedDepsMap);
     }

--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -15,6 +15,7 @@ import { homedir } from "os";
 import { promises as async_fs } from 'fs';
 import fs from 'fs';
 import { AlternateRegistry } from "./AlternateRegistry";
+import { updateFeatureDiagnostics } from "../ui/featureDiagnostics";
 
 function parseToml(cargoTomlContent: string, alternateRegistries?: AlternateRegistry[]): Item[] {
   console.log("Parsing...");
@@ -99,12 +100,15 @@ export async function parseAndDecorate(
     StatusBar.setText("Loading", "Parsing Cargo.toml");
     dependencies = parseToml(cargoTomlContent, alternateRegistries);
     if (fetchDeps || !fetchedDeps || !fetchedDepsMap) {
-      const data = await fetchCrateVersions(dependencies, alternateRegistries);
+      const data = await fetchCrateVersions(dependencies, alternateRegistries, editor.document.fileName);
       fetchedDeps = await data[0];
       fetchedDepsMap = data[1];
     }
 
     decorate(editor, fetchedDeps);
+    if (fetchedDepsMap) {
+      updateFeatureDiagnostics(editor.document, fetchedDepsMap);
+    }
     // StatusBar.setText("Info", "Done");
 
   } catch (e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
 } from "vscode";
 import tomlListener from "./core/listener";
 import TomlCommands from "./toml/commands";
-import { VersionCompletions } from "./providers/autoCompletion";
+import { FeaturesCompletions, VersionCompletions } from "./providers/autoCompletion";
 
 export function activate(context: ExtensionContext) {
   const documentSelector: DocumentSelector = { language: "toml", pattern: "**/[Cc]argo.toml" };
@@ -46,12 +46,12 @@ export function activate(context: ExtensionContext) {
     //   new QuickActions(),
     //   { providedCodeActionKinds: [CodeActionKind.QuickFix] }
     // ),
-    // TODO: Register our features auto completions provider
-    // languages.registerCompletionItemProvider(
-    //   documentSelector,
-    //   new FeaturesCompletions(),
-    //   "'", '"'
-    // ),
+    // Register our features auto completions provider
+    languages.registerCompletionItemProvider(
+      documentSelector,
+      new FeaturesCompletions(),
+      "'", '"', "[", ","
+    ),
   );
 
   tomlListener(window.activeTextEditor);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
 import tomlListener from "./core/listener";
 import TomlCommands from "./toml/commands";
 import { FeaturesCompletions, VersionCompletions } from "./providers/autoCompletion";
+import { featureDiagnosticsCollection } from "./ui/featureDiagnostics";
 
 export function activate(context: ExtensionContext) {
   const documentSelector: DocumentSelector = { language: "toml", pattern: "**/[Cc]argo.toml" };
@@ -50,7 +51,7 @@ export function activate(context: ExtensionContext) {
     languages.registerCompletionItemProvider(
       documentSelector,
       new FeaturesCompletions(),
-      "'", '"', "[", ","
+      "[", ","
     ),
   );
 
@@ -58,6 +59,7 @@ export function activate(context: ExtensionContext) {
 
   // Add commands
   context.subscriptions.push(TomlCommands.replaceVersion);
+  context.subscriptions.push(featureDiagnosticsCollection);
 }
 
 export function deactivate() { }

--- a/src/providers/autoCompletion.ts
+++ b/src/providers/autoCompletion.ts
@@ -12,9 +12,8 @@ import {
 } from "vscode";
 
 import { fetchedDepsMap, getFetchedDependency } from "../core/listener";
-import { checkVersion } from "../semver/semverUtils";
 
-import { RE_VERSION, RE_FEATURES, findCrate, findCrateAndVersion } from "../toml/parser";
+import { RE_VERSION, findCrate, findCrateAndVersion } from "../toml/parser";
 
 const alphabet = "abcdefghijklmnopqrstuvwxyz";
 export function sortText(i: number): string {
@@ -22,6 +21,49 @@ export function sortText(i: number): string {
   const columns = Math.floor(i / alphabet.length);
   const letter = alphabet[i % alphabet.length];
   return "z".repeat(columns) + letter;
+}
+
+function sortFeaturesForCompletion(features: string[]): string[] {
+  return [...features].sort((a, b) => {
+    if (a === "default" && b !== "default") return -1;
+    if (b === "default" && a !== "default") return 1;
+
+    const aUnderscore = a.startsWith("_");
+    const bUnderscore = b.startsWith("_");
+
+    if (aUnderscore && !bUnderscore) return 1;
+    if (!aUnderscore && bUnderscore) return -1;
+
+    return a.localeCompare(b);
+  });
+}
+
+function filterSelectedFeatures(candidates: string[], selected: string[]): string[] {
+  const selectedSet = new Set(selected);
+  return candidates.filter((feature) => !selectedSet.has(feature));
+}
+
+function extractSelectedFeatures(arrayText: string): string[] {
+  const selected = new Set<string>();
+  const regex = /["']([^"']+)["']/g;
+  let match: RegExpExecArray | null = null;
+  while ((match = regex.exec(arrayText)) !== null) {
+    selected.add(match[1]);
+  }
+  return [...selected];
+}
+
+function selectFeatureCandidates(params: {
+  features?: string[];
+  selected?: string[];
+}): string[] {
+  const {
+    features = [],
+    selected = [],
+  } = params;
+
+  const sorted = sortFeaturesForCompletion(features);
+  return filterSelectedFeatures(sorted, selected);
 }
 
 export class VersionCompletions implements CompletionItemProvider {
@@ -70,8 +112,8 @@ export class VersionCompletions implements CompletionItemProvider {
         return new CompletionList(
           (filterVersion.length > 0
             ? fetchedDep.versions.filter((version) =>
-                version.toLowerCase().startsWith(filterVersion)
-              )
+              version.toLowerCase().startsWith(filterVersion)
+            )
             : fetchedDep.versions
           ).map((version) => {
             const item = new CompletionItem(version, CompletionItemKind.Class);
@@ -91,6 +133,88 @@ export class VersionCompletions implements CompletionItemProvider {
 }
 
 export class FeaturesCompletions implements CompletionItemProvider {
+  private getTokenRange(document: TextDocument, position: Position): Range {
+    const lineText = document.lineAt(position.line).text;
+    let start = position.character;
+    let end = position.character;
+
+    while (start > 0 && /[A-Za-z0-9_-]/.test(lineText[start - 1])) {
+      start--;
+    }
+    while (end < lineText.length && /[A-Za-z0-9_-]/.test(lineText[end])) {
+      end++;
+    }
+
+    return new Range(new Position(position.line, start), new Position(position.line, end));
+  }
+
+  private isInsideQuote(document: TextDocument, position: Position): boolean {
+    const lineText = document.lineAt(position.line).text.slice(0, position.character);
+    const doubleQuotes = (lineText.match(/(?<!\\)"/g) ?? []).length;
+    const singleQuotes = (lineText.match(/(?<!\\)'/g) ?? []).length;
+    return doubleQuotes % 2 === 1 || singleQuotes % 2 === 1;
+  }
+
+  private findFeatureArrayContext(document: TextDocument, position: Position): { range: Range; selected: string[] } | undefined {
+    const headerRegex = /^\s*\[.+\]\s*$/;
+    const startRegex = /features\s*=\s*\[/;
+
+    let startLine = -1;
+    let startCharacter = -1;
+
+    for (let line = position.line; line >= Math.max(0, position.line - 80); line--) {
+      const text = document.lineAt(line).text;
+
+      if (line !== position.line && headerRegex.test(text)) {
+        break;
+      }
+
+      const startMatch = text.match(startRegex);
+      if (startMatch) {
+        startLine = line;
+        startCharacter = startMatch.index! + startMatch[0].length;
+        break;
+      }
+    }
+
+    if (startLine < 0 || startCharacter < 0) return;
+
+    let endLine = startLine;
+    let endCharacter = -1;
+    let fullArrayText = document.lineAt(startLine).text.slice(startCharacter);
+
+    const sameLineEnd = fullArrayText.indexOf("]");
+    if (sameLineEnd >= 0) {
+      endCharacter = startCharacter + sameLineEnd;
+      fullArrayText = fullArrayText.slice(0, sameLineEnd);
+    } else {
+      for (let line = startLine + 1; line < Math.min(document.lineCount, startLine + 120); line++) {
+        const text = document.lineAt(line).text;
+        const closeIdx = text.indexOf("]");
+        if (closeIdx >= 0) {
+          endLine = line;
+          endCharacter = closeIdx;
+          fullArrayText += "\n" + text.slice(0, closeIdx);
+          break;
+        }
+        fullArrayText += "\n" + text;
+      }
+    }
+
+    if (endCharacter < 0) return;
+
+    const range = new Range(
+      new Position(startLine, startCharacter),
+      new Position(endLine, endCharacter)
+    );
+    if (!range.contains(position)) return;
+
+    return {
+      range,
+      selected: extractSelectedFeatures(fullArrayText),
+    };
+  }
+
   provideCompletionItems(
     document: TextDocument,
     position: Position,
@@ -99,39 +223,45 @@ export class FeaturesCompletions implements CompletionItemProvider {
   ): ProviderResult<CompletionItem[] | CompletionList> {
     if (!fetchedDepsMap) return;
 
-    const line = document.lineAt(position);
+    const context = this.findFeatureArrayContext(document, position);
+    if (!context) return;
 
-    const featuresMatch = line.text.match(RE_FEATURES);
-    if (featuresMatch) {
-      let crate;
-      let version;
-      const versionMatch = line.text.match(RE_VERSION);
-      if (versionMatch) {
-        crate = versionMatch[1];
-        version = versionMatch[7] ?? versionMatch[5];
+    let crate: string | undefined;
+    const versionMatch = document.lineAt(position).text.match(RE_VERSION);
+    if (versionMatch) {
+      crate = versionMatch[1] === "version" ? findCrate(document, position.line + 1) : versionMatch[1];
+    } else {
+      const match = findCrateAndVersion(document, position.line);
+      if (match) {
+        [crate] = match;
       } else {
-        const match = findCrateAndVersion(document, position.line);
-        if (!match) return;
-        [crate, version] = match;
+        crate = findCrate(document, position.line + 1);
       }
-      
-      const fetchedDep = getFetchedDependency(document, crate, position);
-      if (!fetchedDep || !fetchedDep.featureCompletionItems || !fetchedDep.versions) return;
-
-      const featuresArray = featuresMatch[2];
-
-      const featuresStart = featuresMatch[1].length;
-      const featuresEnd = featuresStart + featuresArray.length;
-
-      const featuresRange = new Range(
-        new Position(position.line, featuresStart),
-        new Position(position.line, featuresEnd)
-      );
-
-      if (!featuresRange.contains(position)) return;
-
-      const maxSatisfying = checkVersion(version, fetchedDep.versions)[1] ?? version;
-      return fetchedDep.featureCompletionItems.get(maxSatisfying);
     }
+
+    if (!crate) return;
+
+    const fetchedDep = getFetchedDependency(document, crate, position);
+    if (!fetchedDep || !fetchedDep.features) return;
+
+    const candidates = selectFeatureCandidates({
+      features: fetchedDep.features,
+      selected: context.selected,
+    });
+
+    const tokenRange = this.getTokenRange(document, position);
+    const insideQuote = this.isInsideQuote(document, position);
+
+    let i = 0;
+    return new CompletionList(
+      candidates.map((candidate) => {
+        const item = new CompletionItem(candidate, CompletionItemKind.Field);
+        item.sortText = sortText(i++);
+        item.range = tokenRange;
+        item.insertText = insideQuote ? candidate : `"${candidate}"`;
+        return item;
+      }),
+      true
+    );
   }
 }

--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -277,7 +277,7 @@ function parseValues(data: string, parent: Item, index: number): number {
 function isCratesDep(i: Item): boolean {
   if (i.values && i.values.length) {
     for (let value of i.values) {
-      if (value.key === "git" || value.key === "path") {
+      if (value.key === "git") {
         return false;
       } else if (value.key === "package" && value.value !== undefined) {
         i.key = value.value;

--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -66,7 +66,6 @@ export function findCrateAndVersion(
 function findVersion(item: Item): Item[] {
   let dependencies: Item[] = [];
   for (const field of item.values) {
-    if (field.key.endsWith(".workspace") || field.key.endsWith(".path")) continue;
     if (field.values.length > 0) {
       const dependency = findVersionTable(field);
       if (dependency) dependencies.push(dependency);
@@ -82,17 +81,33 @@ function findVersionTable(table: Item): Item | null {
   let item = null
   let itemName = null;
   let itemRegistry = undefined;
+  let itemPath = undefined;
+  let itemWorkspace: boolean | undefined = undefined;
   for (const field of table.values) {
-    if (field.key === "workspace" || field.key === "path") return null;
     if (field.key === "version") {
       item = new Item(field);
       item.key = table.key;
     }
     if (field.key === "package") itemName = field.value;
     if (field.key === "registry") itemRegistry = field.value;
+    if (field.key === "path") itemPath = field.value;
+    if (field.key === "workspace") itemWorkspace = field.value === "true";
   }
+
+  if (!item && (itemPath !== undefined || itemWorkspace === true)) {
+    item = new Item(table);
+    item.key = table.key;
+    item.value = undefined;
+  }
+
   if (item && itemName) item.key = itemName;
   if (item && itemRegistry !== undefined) item.registry = itemRegistry;
+  if (item && itemPath !== undefined) item.path = itemPath;
+  if (item && itemWorkspace !== undefined) item.workspace = itemWorkspace;
+  if (item) {
+    item.start = table.start;
+    item.end = table.end;
+  }
   return item;
 }
 

--- a/src/ui/decorator.ts
+++ b/src/ui/decorator.ts
@@ -66,13 +66,13 @@ function loadPref() {
   const incompatibleDecoratorText = config.get<string>("crates.incompatibleDecorator") ?? "";
   let incompatibleDecoratorCss = config.get<DecorationInstanceRenderOptions>("crates.incompatibleDecoratorCss") ?? {};
   const errorDecoratorText = errorText ? errorText + "" : "";
-  if(compatibleDecoratorCss.after == undefined) {
+  if (compatibleDecoratorCss.after == undefined) {
     compatibleDecoratorCss.after = {}
   }
-  if(incompatibleDecoratorCss.after == undefined) {
+  if (incompatibleDecoratorCss.after == undefined) {
     incompatibleDecoratorCss.after = {}
   }
-  if(errorDecoratorCss.after == undefined) {
+  if (errorDecoratorCss.after == undefined) {
     errorDecoratorCss.after = {}
   }
   compatibleDecoratorCss.after.contentText = compatibleDecoratorText;

--- a/src/ui/featureDiagnostics.ts
+++ b/src/ui/featureDiagnostics.ts
@@ -125,16 +125,21 @@ function collectFeatureUsages(document: TextDocument): FeatureUsage[] {
 }
 
 function findDependencyForCrate(
+    document: TextDocument,
     fetchedDepsMap: Map<string, Dependency[]>,
     crate: string,
-    line: number
+    usageOffset: number
 ): Dependency | undefined {
     const deps = fetchedDepsMap.get(crate);
     if (!deps || deps.length === 0) return undefined;
     if (deps.length === 1) return deps[0];
 
     for (const dep of deps) {
-        if (dep.item.start <= line && line <= dep.item.end) {
+        const depRange = new Range(
+            document.positionAt(dep.item.start),
+            document.positionAt(dep.item.end)
+        );
+        if (depRange.contains(document.positionAt(usageOffset))) {
             return dep;
         }
     }
@@ -159,8 +164,10 @@ export function updateFeatureDiagnostics(
     const usages = collectFeatureUsages(document);
 
     usages.forEach((usage) => {
-        const dep = findDependencyForCrate(fetchedDepsMap, usage.crate, usage.range.start.line);
+        const usageOffset = document.offsetAt(usage.range.start);
+        const dep = findDependencyForCrate(document, fetchedDepsMap, usage.crate, usageOffset);
         if (!dep) return;
+        if (dep.error) return;
 
         const available = resolveAvailableFeatures(dep);
         const unknown = findUnknownFeatures(usage.selected, available);

--- a/src/ui/featureDiagnostics.ts
+++ b/src/ui/featureDiagnostics.ts
@@ -1,0 +1,180 @@
+import {
+    Diagnostic,
+    DiagnosticCollection,
+    DiagnosticSeverity,
+    Position,
+    Range,
+    TextDocument,
+    Uri,
+    languages,
+} from "vscode";
+import Dependency from "../core/Dependency";
+
+const DEP_TABLE_HEADER = /^\s*\[(?:.+\.)?(?:dev-)?dependencies(?:\.([^.\]]+))?\]\s*$/;
+const INLINE_DEP = /^\s*([^\s=]+)\s*=\s*\{(.+)\}\s*$/;
+
+export const featureDiagnosticsCollection: DiagnosticCollection =
+    languages.createDiagnosticCollection("crates-io-features");
+
+function extractSelectedFeatures(arrayText: string): string[] {
+    const matches = arrayText.matchAll(/["']([^"']+)["']/g);
+    return [...new Set(Array.from(matches, (match) => match[1]))];
+}
+
+type FeatureUsage = {
+    crate: string;
+    version?: string;
+    selected: string[];
+    range: Range;
+};
+
+function collectArrayTextUntilClose(document: TextDocument, line: number, startIdx: number): {
+    arrayText: string;
+    endLine: number;
+    endChar: number;
+} | undefined {
+    let arrayText = document.lineAt(line).text.slice(startIdx);
+    const sameLineClose = arrayText.indexOf("]");
+    if (sameLineClose >= 0) {
+        return {
+            arrayText: arrayText.slice(0, sameLineClose),
+            endLine: line,
+            endChar: startIdx + sameLineClose,
+        };
+    }
+
+    for (let i = line + 1; i < document.lineCount; i++) {
+        const text = document.lineAt(i).text;
+        const closeIdx = text.indexOf("]");
+        if (closeIdx >= 0) {
+            return {
+                arrayText: arrayText + "\n" + text.slice(0, closeIdx),
+                endLine: i,
+                endChar: closeIdx,
+            };
+        }
+        arrayText += "\n" + text;
+    }
+
+    return undefined;
+}
+
+function collectFeatureUsages(document: TextDocument): FeatureUsage[] {
+    const usages: FeatureUsage[] = [];
+    let currentTableCrate: string | undefined;
+    let currentTableVersion: string | undefined;
+
+    for (let line = 0; line < document.lineCount; line++) {
+        const text = document.lineAt(line).text;
+
+        const tableHeader = text.match(DEP_TABLE_HEADER);
+        if (tableHeader) {
+            currentTableCrate = tableHeader[1];
+            currentTableVersion = undefined;
+            continue;
+        }
+
+        if (/^\s*\[.+\]\s*$/.test(text)) {
+            currentTableCrate = undefined;
+            currentTableVersion = undefined;
+            continue;
+        }
+
+        const inlineDep = text.match(INLINE_DEP);
+        if (inlineDep) {
+            const crate = inlineDep[1].replace(/^"|"$/g, "");
+            const body = inlineDep[2];
+            const featuresMatch = body.match(/features\s*=\s*\[(.*?)\]/);
+            if (featuresMatch) {
+                const versionMatch = body.match(/version\s*=\s*["']([^"']+)["']/);
+                usages.push({
+                    crate,
+                    version: versionMatch?.[1],
+                    selected: extractSelectedFeatures(featuresMatch[1]),
+                    range: new Range(new Position(line, 0), new Position(line, text.length)),
+                });
+            }
+            continue;
+        }
+
+        if (currentTableCrate) {
+            const versionMatch = text.match(/^\s*version\s*=\s*["']([^"']+)["']/);
+            if (versionMatch) {
+                currentTableVersion = versionMatch[1];
+            }
+
+            const featuresStartMatch = text.match(/^\s*features\s*=\s*\[/);
+            if (featuresStartMatch) {
+                const start = featuresStartMatch.index! + featuresStartMatch[0].length;
+                const arrayData = collectArrayTextUntilClose(document, line, start);
+                if (!arrayData) continue;
+
+                usages.push({
+                    crate: currentTableCrate,
+                    version: currentTableVersion,
+                    selected: extractSelectedFeatures(arrayData.arrayText),
+                    range: new Range(new Position(line, 0), new Position(arrayData.endLine, arrayData.endChar)),
+                });
+
+                line = arrayData.endLine;
+            }
+        }
+    }
+
+    return usages;
+}
+
+function findDependencyForCrate(
+    fetchedDepsMap: Map<string, Dependency[]>,
+    crate: string,
+    line: number
+): Dependency | undefined {
+    const deps = fetchedDepsMap.get(crate);
+    if (!deps || deps.length === 0) return undefined;
+    if (deps.length === 1) return deps[0];
+
+    for (const dep of deps) {
+        if (dep.item.start <= line && line <= dep.item.end) {
+            return dep;
+        }
+    }
+
+    return deps[0];
+}
+
+function resolveAvailableFeatures(dep: Dependency): string[] {
+    return dep.features ?? [];
+}
+
+export function findUnknownFeatures(selected: string[], available: string[]): string[] {
+    const availableSet = new Set(available);
+    return selected.filter((feature) => !availableSet.has(feature));
+}
+
+export function updateFeatureDiagnostics(
+    document: TextDocument,
+    fetchedDepsMap: Map<string, Dependency[]>
+): void {
+    const diagnostics: Diagnostic[] = [];
+    const usages = collectFeatureUsages(document);
+
+    usages.forEach((usage) => {
+        const dep = findDependencyForCrate(fetchedDepsMap, usage.crate, usage.range.start.line);
+        if (!dep) return;
+
+        const available = resolveAvailableFeatures(dep);
+        const unknown = findUnknownFeatures(usage.selected, available);
+
+        if (unknown.length > 0) {
+            diagnostics.push(
+                new Diagnostic(
+                    usage.range,
+                    `Unknown feature(s) for ${usage.crate}: ${unknown.join(", ")}`,
+                    DiagnosticSeverity.Warning
+                )
+            );
+        }
+    });
+
+    featureDiagnosticsCollection.set(document.uri as Uri, diagnostics);
+}


### PR DESCRIPTION
I've added a new feature that queries dependencies' features by used version, along with suggestions and auto-completion.

Entering a comma or double quote in the `features` array triggers suggestions; selecting the desired feature and pressing Enter completes the auto-completion.

<img width="563" height="158" alt="screen_shot_2026-02-28-17-12-45" src="https://github.com/user-attachments/assets/83bc2188-116f-4e21-99df-7e4b64579559" />

Ignore the two lines of double quotes. They were created by "even better toml" extension. :)

I referenced the specification of the [tombi cargo extension](https://tombi-toml.github.io/tombi/docs/extensions/tombi-extension-cargo#crate-feature-completion).
1. Fetches available features from:crates.io for registry dependencies;Local Cargo.toml for path dependencies;Workspace Cargo.toml for workspace dependencies
2. Filters out already selected features
3. default feature shown first, features starting with _ shown last
4. context-aware: when a dependency uses workspace = true, it looks up features from the workspace definition.

To be honest, the code was generated by GPT-5.3, and I only did some simple checks and tests.