### PR TITLE
fix: detect Cargo.toml in root folder too

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   ],
   "activationEvents": [
     "onLanguage:toml",
-    "workspaceContains:Cargo.toml",
-    "workspaceContains:*/Cargo.toml"
+    "workspaceContains:**/Cargo.toml"
   ],
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "activationEvents": [
     "onLanguage:toml",
+    "workspaceContains:Cargo.toml",
     "workspaceContains:*/Cargo.toml"
   ],
   "contributes": {


### PR DESCRIPTION
Hi! Thank you for the maintenance of this wonderful extension!
Previously, I used it for a Tauri project, and it worked great, `Cargo.toml` is located inside `src-tauri` subfolder for Tauri.
But I've just found out that the extension doesn't get activated for regular Rust libraries where `Cargo.toml` is located in root folder. This PR makes the extension activate for root-level `Cargo.toml`.